### PR TITLE
Add focus to list of options

### DIFF
--- a/build/lib/ng2-nvd3.component.js
+++ b/build/lib/ng2-nvd3.component.js
@@ -69,6 +69,7 @@ var NvD3Component = (function () {
                 'discretebar',
                 'distX',
                 'distY',
+                'focus',
                 'interactiveLayer',
                 'legend',
                 'lines',

--- a/lib/ng2-nvd3.component.ts
+++ b/lib/ng2-nvd3.component.ts
@@ -102,6 +102,7 @@ export class NvD3Component implements OnChanges, OnDestroy {
         'discretebar',
         'distX',
         'distY',
+        'focus',
         'interactiveLayer',
         'legend',
         'lines',


### PR DESCRIPTION
There was a bug when trying to use events dispatched by `focus` on `lineWithFocusChart`. Adding focus to  the list of options to check fixed the issue.