### PR TITLE
Add focus to the list of options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ cache:
       - node_modules
 
 before_install:
-  - npm install -g typings
   - npm install -g karma-cli
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
@@ -23,5 +22,4 @@ before_install:
 
 script:
   - npm install
-  - typings install
   - ./node_modules/.bin/karma start karma.conf.js --auto-watch --single-run --reporters dots,coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js: stable
 
-sudo: false
+sudo: required
 dist: trusty
 
 install: true # yarn bug

--- a/build/lib/ng2-nvd3.component.d.ts
+++ b/build/lib/ng2-nvd3.component.d.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/globals/d3/index.d.ts" />
-/// <reference path="../../typings/globals/nvd3/index.d.ts" />
 import { OnChanges, OnDestroy, ElementRef, SimpleChanges } from '@angular/core';
 export declare class NvD3Component implements OnChanges, OnDestroy {
     options: any;

--- a/build/lib/ng2-nvd3.component.js
+++ b/build/lib/ng2-nvd3.component.js
@@ -1,6 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var core_1 = require("@angular/core");
+var d3 = require("d3");
+var nv = require("nvd3");
 var NvD3Component = (function () {
     function NvD3Component(elementRef) {
         this.el = elementRef.nativeElement;

--- a/build/lib/ng2-nvd3.component.js
+++ b/build/lib/ng2-nvd3.component.js
@@ -69,6 +69,7 @@ var NvD3Component = (function () {
                 'discretebar',
                 'distX',
                 'distY',
+                'focus',
                 'interactiveLayer',
                 'legend',
                 'lines',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,8 +39,12 @@ module.exports = function (config) {
       noInfo: true
     },
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['Chrome', 'ChromeHeadless', 'ChromeHeadlessNoSandbox'],
     customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      },
       chrome_travis_ci: {
         base: 'Chrome',
         flags: ['--no-sandbox']

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,6 +19,7 @@ module.exports = function (config) {
       'test/vendor.ts': ['webpack', 'sourcemap'],
       'test/*.spec.ts': ['webpack', 'sourcemap']
     },
+    logLevel: config.LOG_DEBUG,
     webpack: {
       devtool: 'source-map',
       module: {

--- a/lib/ng2-nvd3.component.ts
+++ b/lib/ng2-nvd3.component.ts
@@ -102,6 +102,7 @@ export class NvD3Component implements OnChanges, OnDestroy {
         'discretebar',
         'distX',
         'distY',
+        'focus',
         'interactiveLayer',
         'legend',
         'lines',

--- a/lib/ng2-nvd3.component.ts
+++ b/lib/ng2-nvd3.component.ts
@@ -1,6 +1,6 @@
-/// <reference path="../typings/globals/d3/index.d.ts" />
-/// <reference path="../typings/globals/nvd3/index.d.ts" />
 import { Component, OnChanges, OnDestroy, ElementRef, Input, SimpleChanges } from '@angular/core';
+import * as d3 from 'd3';
+import * as nv from 'nvd3';
 
 @Component({
   selector: 'nvd3',

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "pretest": "npm run build",
     "test": "karma start karma.conf.js",
-    "build": "rm -rf build && ngc -p ./tsconfig.publish.json",
-    "prepublish": "typings install && npm run build"
+    "build": "rm -rf build && ngc -p ./tsconfig.publish.json"
   },
   "author": "Konstantin Skipor",
   "repository": {
@@ -26,10 +25,12 @@
     "url": "https://github.com/krispo/ng2-nvd3"
   },
   "dependencies": {
+    "@types/nvd3": "^1.8.38",
+    "@types/d3":"3.5.40",
+    "d3": "3.5.17",
+    "nvd3": "1.8.5",
     "reflect-metadata": "^0.1.10",
-    "rxjs": "5.2.0",
-    "d3": "^3.5.15",
-    "nvd3": "^1.8.5"
+    "rxjs": "5.2.0"
   },
   "devDependencies": {
     "@angular/common": "^2.4 || ^4.0",
@@ -38,13 +39,15 @@
     "@angular/core": "^2.4 || ^4.0",
     "@angular/platform-browser": "^2.4 || ^4.0",
     "@angular/platform-browser-dynamic": "^2.4 || ^4.0",
+    "@types/d3": "3.5.40",
     "@types/jasmine": "^2.5.51",
+    "@types/nvd3": "^1.8.38",
     "es6-promise": "^4.0.5",
     "es6-shim": "^0.35.3",
     "jasmine": "^2.5.3",
     "jasmine-core": "2.5.2",
-    "karma": "1.5.0",
-    "karma-chrome-launcher": "^2.0.0",
+    "karma": "2.0.0",
+    "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.1.0",
     "karma-remap-istanbul": "^0.6.0",
@@ -52,7 +55,6 @@
     "karma-webpack": "^2.0.2",
     "ts-loader": "^2.0",
     "typescript": "2.3.4",
-    "typings": "^2.1.0",
     "webpack": "^1.14.0",
     "zone.js": "^0.7.7"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noImplicitAny": false,
     "declaration": true,
     "sourceMap": false,
-    "types": ["jasmine"],
+    "types": ["jasmine", "d3", "nvd3"],
     "outDir": "build"
   },
   "include": [

--- a/tsconfig.publish.json
+++ b/tsconfig.publish.json
@@ -10,7 +10,11 @@
     "noImplicitAny": false,
     "declaration": true,
     "sourceMap": false,
-    "types": ["jasmine"],
+    "types": [
+      "jasmine",
+      "d3",
+      "nvd3"
+    ],
     "outDir": "build"
   },
   "files": [

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,0 @@
- {
-  "dependencies": {},
-  "globalDependencies": {
-    "d3": "registry:dt/d3#0.0.0+20160907005744",
-    "nvd3": "registry:dt/nvd3#1.8.1+20160919061516"
-  }
-}


### PR DESCRIPTION
When trying to create a `lineWithFocusChart` with `focus` option to handle dispatched events by the focus an error occurs. 

```
ERROR TypeError: selection.each is not a function
    at Function.chart [as focus] (nv.d3.js:4723)
    at NvD3Component.updateWithOptions (ng2-nvd3.component.js:110)
    at NvD3Component.initChart (ng2-nvd3.component.js:29)
    at NvD3Component.ngOnChanges (ng2-nvd3.component.js:11)
    at checkAndUpdateDirectiveInline (core.js:12348)
    at checkAndUpdateNodeInline (core.js:13876)
    at checkAndUpdateNode (core.js:13819)
    at debugCheckAndUpdateNode (core.js:14712)
    at debugCheckDirectivesFn (core.js:14653)
    at Object.eval [as updateDirectives] (StockSalesComponent.html:2)
```