### PR TITLE
remove duplicate SVG element

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/krispo/ng2-nvd3.svg?branch=master)](https://travis-ci.org/krispo/ng2-nvd3)
 [![NPM Version](http://img.shields.io/npm/v/ng2-nvd3.svg?style=flat)](https://www.npmjs.org/package/ng2-nvd3)
 
-Angular component for nvd3 (uses d3 v3!). It has similar technique as [angular-nvd3](http://krispo.github.io/angular-nvd3) for angular 1, but designed for angular 2+ and without extra features (like extended mode) you won't need.
+A fork of krispo's Angular component for nvd3 (uses d3 v3!). It has similar technique as [angular-nvd3](http://krispo.github.io/angular-nvd3) for angular 1, but designed for angular 2+ and without extra features (like extended mode) you won't need.
 
 ## Demos
 
@@ -147,7 +147,11 @@ Special thanks to [Tobias Walle](https://github.com/TobiasWalle) and [MaibornWol
     
 ## Change Log
 
-#### 2.0.0 (master)
+#### 2.0.3 (master)
+
+Fixed resizing bug that produced duplicate sankey charts
+
+#### 2.0.0
 
 Fixed `aot` issue [#104](https://github.com/krispo/ng2-nvd3/pull/104) 
 

--- a/build/lib/ng2-nvd3.component.js
+++ b/build/lib/ng2-nvd3.component.js
@@ -118,7 +118,9 @@ var NvD3Component = (function () {
                 this.svg = d3.select(this.el).append('svg');
             }
             else {
-                svgElement.querySelector('svg').remove();
+                if (svgElement.querySelector('svg')) {
+                    svgElement.querySelector('svg').remove();
+                }
                 this.svg = d3.select(svgElement);
             }
             this.updateSize();

--- a/build/lib/ng2-nvd3.component.js
+++ b/build/lib/ng2-nvd3.component.js
@@ -113,14 +113,13 @@ var NvD3Component = (function () {
     };
     NvD3Component.prototype.updateWithData = function (data) {
         if (data) {
-            {
-                var svgElement = this.el.querySelector('svg');
-                if (!svgElement) {
-                    this.svg = d3.select(this.el).append('svg');
-                }
-                else {
-                    this.svg = d3.select(svgElement);
-                }
+            var svgElement = this.el.querySelector('svg');
+            if (!svgElement) {
+                this.svg = d3.select(this.el).append('svg');
+            }
+            else {
+                svgElement.querySelector('svg').remove();
+                this.svg = d3.select(svgElement);
             }
             this.updateSize();
             this.svg.datum(data).call(this.chart);

--- a/lib/ng2-nvd3.component.ts
+++ b/lib/ng2-nvd3.component.ts
@@ -157,13 +157,12 @@ export class NvD3Component implements OnChanges, OnDestroy {
     if (data) {
 
       // Select the add <svg> element (create it if necessary) and to render the chart in
-      {
-        let svgElement = this.el.querySelector('svg');
-        if (!svgElement) {
-          this.svg = d3.select(this.el).append('svg');
-        } else {
-          this.svg = d3.select(svgElement);
-        }
+      let svgElement = this.el.querySelector('svg');
+      if (!svgElement) {
+        this.svg = d3.select(this.el).append('svg');
+      } else {
+        svgElement.querySelector('svg').remove();
+        this.svg = d3.select(svgElement);
       }
 
       this.updateSize();

--- a/lib/ng2-nvd3.component.ts
+++ b/lib/ng2-nvd3.component.ts
@@ -161,7 +161,9 @@ export class NvD3Component implements OnChanges, OnDestroy {
       if (!svgElement) {
         this.svg = d3.select(this.el).append('svg');
       } else {
-        svgElement.querySelector('svg').remove();
+        if (svgElement.querySelector('svg')) {
+          svgElement.querySelector('svg').remove();
+        }
         this.svg = d3.select(svgElement);
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mike-j-w/ng2-nvd3",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Angular2 component for NVD3.js reusable charting library",
   "keywords": [
     "angular2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ng2-nvd3",
-  "version": "2.0.0",
+  "name": "@mike-j-w/ng2-nvd3",
+  "version": "2.0.2",
   "description": "Angular2 component for NVD3.js reusable charting library",
   "keywords": [
     "angular2",
@@ -17,8 +17,7 @@
   "scripts": {
     "pretest": "npm run build",
     "test": "karma start karma.conf.js",
-    "build": "rm -rf build && ngc -p ./tsconfig.publish.json",
-    "prepublish": "typings install && npm run build"
+    "build": "rm -rf build && ngc -p ./tsconfig.publish.json"
   },
   "author": "Konstantin Skipor",
   "repository": {


### PR DESCRIPTION
When updating a chart, a new SVG is always appended.  Remove the old one first to avoid duplicate images.